### PR TITLE
fix : 공개 일기 조회시 비밀일기 조회 안되게 수정

### DIFF
--- a/src/main/java/com/kernel/sense_log/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/kernel/sense_log/domain/repository/DiaryRepository.java
@@ -31,4 +31,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
   Diary findByWriterIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
   Page<Diary> findAllByWriterIdAndCreatedAtBetween(Long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
+
+  Page<Diary> findByIsPrivateAndCreatedAtBetween(boolean isPrivate, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+  Page<Diary> findByTagAndIsPrivateAndCreatedAtBetween(Tag tag, boolean isPrivate, LocalDateTime start, LocalDateTime end, Pageable pageable);
 }

--- a/src/main/java/com/kernel/sense_log/domain/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/kernel/sense_log/domain/service/impl/DiaryServiceImpl.java
@@ -51,8 +51,7 @@ public class DiaryServiceImpl implements DiaryService {
 
     LocalDateTime start = baseDate.atTime(5, 0);
     LocalDateTime end = baseDate.plusDays(1).atTime(5, 0);
-    return diaryRepository.findAllByCreatedAtBetween(start, end, pageable);
-
+    return diaryRepository.findByIsPrivateAndCreatedAtBetween(false, start, end, pageable);
   }
 
   @Override
@@ -99,6 +98,6 @@ public class DiaryServiceImpl implements DiaryService {
 
     LocalDateTime start = baseDate.atTime(5, 0);
     LocalDateTime end = baseDate.plusDays(1).atTime(5, 0);
-    return diaryRepository.findByTagAndCreatedAtBetween(tag, start, end, pageable);
+    return diaryRepository.findByTagAndIsPrivateAndCreatedAtBetween(tag, false, start, end, pageable);
   }
 }


### PR DESCRIPTION
# Pull Request
## 📝 PR 설명

- 공개 일기 조회시 비밀일기 조회 안되게 수정하였습니다.

---

## ✅ 작업 내용 체크리스트

- [ ] 새로운 기능 추가
- [x] 기존 기능 수정
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서/README 수정

---

## 🔍 관련 이슈

- 관련된 이슈 번호 또는 설명을 연결해 주세요.
    - ex) resolves #12

---

## 🧩 참고 자료 (선택)

- API 명세서, 디자인 링크, 노션 문서 등